### PR TITLE
Uncommented HttpEnabled Checks - Hotfix

### DIFF
--- a/src/MarcSync/MarcSyncv1.0.lua
+++ b/src/MarcSync/MarcSyncv1.0.lua
@@ -52,8 +52,7 @@ return {
 		self._checkInstallation = function()
 			if not self then error("Please Setup MarcSync before using MarcSync.") end
 			if not self._accessToken then error("[MarcSync] Please set a Token before using MarcSync.") end
-			--print(HttpService.HttpEnabled)
-			--if not HttpService.HttpEnabled then error("Please Enable HTTPService in order to use MarcSync.") end
+			if not HttpService.HttpEnabled then error("Please Enable HTTPService in order to use MarcSync.") end
 		end
 
 		self = setmetatable(self, {


### PR DESCRIPTION
Since V0.5 it hasn't been uncommented, completly ignored the fact that at some point in development we have commented the warning/error, which checks rather HTTP is enabled in-game, out.

For some reason, even after the entire, big, SyntaxUpdate to V1.0 it hasn't been noticed and just has been taken over in it.

Those lines came to my notice when I just installed MarcSync into my game and was wondering why it wasn't working and why there was no HTTP Error in the console by MarcSync, because I knew that there was something like that in the code, but yeah, it was commented out since ages without notice. What a tragedy, init?